### PR TITLE
feat: add capabilities_verified to IssuerCapabilities (referenced in docs but missing from schema/SDKs)

### DIFF
--- a/cli/src/commands/register.ts
+++ b/cli/src/commands/register.ts
@@ -41,7 +41,8 @@ export const register = async (options: RegisterOptions) => {
             "audit_logging": true,
             "immutable_audit": false,
             "attestation_format": "jwt",
-            "max_attestation_ttl_seconds": 3600
+            "max_attestation_ttl_seconds": 3600,
+            "capabilities_verified": false
         }
     };
 

--- a/registry/issuers/arcede.json
+++ b/registry/issuers/arcede.json
@@ -23,6 +23,7 @@
     "audit_logging": true,
     "immutable_audit": false,
     "attestation_format": "jwt",
-    "max_attestation_ttl_seconds": 3600
+    "max_attestation_ttl_seconds": 3600,
+    "capabilities_verified": false
   }
 }

--- a/sdk/swift/Sources/OpenAgentTrustRegistry/Types.swift
+++ b/sdk/swift/Sources/OpenAgentTrustRegistry/Types.swift
@@ -45,6 +45,11 @@ public struct IssuerCapabilities: Codable {
     public let immutableAudit: Bool
     public let attestationFormat: String
     public let maxAttestationTtlSeconds: Int
+    /// `false` for all new registrations (Tier 1 automated inclusion).
+    /// Set to `true` by community auditors after independently verifying the
+    /// capability claims above (Tier 2 review). Services may gate high-stakes
+    /// operations on this flag. See GOVERNANCE.md for the review process.
+    public let capabilitiesVerified: Bool
 
     enum CodingKeys: String, CodingKey {
         case supervisionModel = "supervision_model"
@@ -52,6 +57,7 @@ public struct IssuerCapabilities: Codable {
         case immutableAudit = "immutable_audit"
         case attestationFormat = "attestation_format"
         case maxAttestationTtlSeconds = "max_attestation_ttl_seconds"
+        case capabilitiesVerified = "capabilities_verified"
     }
 }
 

--- a/sdk/swift/Tests/OpenAgentTrustRegistryTests/OpenAgentTrustRegistryTests.swift
+++ b/sdk/swift/Tests/OpenAgentTrustRegistryTests/OpenAgentTrustRegistryTests.swift
@@ -62,7 +62,8 @@ final class AgentTrustRegistryTests: XCTestCase {
             auditLogging: false,
             immutableAudit: false,
             attestationFormat: "jwt",
-            maxAttestationTtlSeconds: 3600
+            maxAttestationTtlSeconds: 3600,
+            capabilitiesVerified: false
         )
 
         let validIssuer = IssuerEntry(

--- a/sdk/typescript/src/types/registry.ts
+++ b/sdk/typescript/src/types/registry.ts
@@ -21,6 +21,18 @@ export interface IssuerCapabilities {
   immutable_audit: boolean;
   attestation_format: string;
   max_attestation_ttl_seconds: number;
+  /**
+   * Whether community auditors have independently verified this issuer's
+   * capability claims. New issuers are automatically included with
+   * `capabilities_verified: false` (Tier 1 registration). Community
+   * reviewers may upgrade to `true` via a separate PR (Tier 2).
+   *
+   * Services may use this field to apply differentiated policies, e.g.
+   * requiring `capabilities_verified: true` for high-stakes operations.
+   *
+   * @see https://github.com/FransDevelopment/open-agent-trust-registry/blob/main/GOVERNANCE.md#tier-2-capability-verification-community-review
+   */
+  capabilities_verified: boolean;
 }
 
 export interface IssuerEndpoints {

--- a/sdk/typescript/src/verify.test.ts
+++ b/sdk/typescript/src/verify.test.ts
@@ -38,7 +38,7 @@ describe('OpenAgentTrustRegistry (Client)', () => {
           status: "active",
           added_at: new Date().toISOString(),
           last_verified: new Date().toISOString(),
-          capabilities: { supervision_model: 'none', audit_logging: false, immutable_audit: false, attestation_format: 'jwt', max_attestation_ttl_seconds: 3600 },
+          capabilities: { supervision_model: 'none', audit_logging: false, immutable_audit: false, attestation_format: 'jwt', max_attestation_ttl_seconds: 3600, capabilities_verified: false },
           public_keys: [
             {
               kid: "valid-key-1",
@@ -70,7 +70,7 @@ describe('OpenAgentTrustRegistry (Client)', () => {
            status: "revoked",
            added_at: new Date().toISOString(),
            last_verified: new Date().toISOString(),
-           capabilities: { supervision_model: 'none', audit_logging: false, immutable_audit: false, attestation_format: 'jwt', max_attestation_ttl_seconds: 3600 },
+           capabilities: { supervision_model: 'none', audit_logging: false, immutable_audit: false, attestation_format: 'jwt', max_attestation_ttl_seconds: 3600, capabilities_verified: false },
            public_keys: [
              {
                kid: "revoked-key-1",

--- a/spec/01-data-model.md
+++ b/spec/01-data-model.md
@@ -49,7 +49,8 @@ Each entry models one trusted attestation issuer.
     "audit_logging": true,
     "immutable_audit": true,
     "attestation_format": "jwt",
-    "max_attestation_ttl_seconds": 3600
+    "max_attestation_ttl_seconds": 3600,
+    "capabilities_verified": false
   },
   "endpoints": {
     "attestation_verify": "https://api.acme.example.com/v1/identity/verify",
@@ -68,8 +69,19 @@ Each entry models one trusted attestation issuer.
 | `added_at` | ISO 8601 | yes | When issuer was added to registry |
 | `last_verified` | ISO 8601 | yes | Last time issuer passed verification check |
 | `public_keys` | array | yes | Array of `PublicKey` objects (at least one active) |
-| `capabilities` | object | yes | Self-declared capabilities of the runtime |
+| `capabilities` | object | yes | Self-declared capabilities of the runtime (see Capabilities sub-fields below) |
 | `endpoints` | object | no | Optional verification/revocation endpoints |
+
+### 2.1 Capabilities Sub-fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `supervision_model` | string | Human oversight model (e.g. `"tiered"`, `"full"`, `"autonomous"`) |
+| `audit_logging` | boolean | Whether the runtime maintains audit logs of agent actions |
+| `immutable_audit` | boolean | Whether the audit log is write-once / tamper-evident |
+| `attestation_format` | string | Token format produced by the runtime (e.g. `"jwt"`) |
+| `max_attestation_ttl_seconds` | integer | Maximum lifetime of any issued attestation, in seconds |
+| `capabilities_verified` | boolean | `false` for all new registrations (automated Tier 1). Community auditors may open a PR setting this to `true` (Tier 2 review) after independently verifying the above claims. Services may use this flag to apply differentiated trust policies (see [Governance Tier 2](../GOVERNANCE.md)). |
 
 ## 3. Public Key Entry
 


### PR DESCRIPTION
## Summary

GOVERNANCE.md, `spec/02-registration.md`, `spec/09-service-integration.md`, and the PR template all reference a `capabilities_verified` field — the Tier 2 marker that community auditors set to `true` after independently verifying an issuer's self-declared capability claims.

However, the field was **missing** from everywhere it needed to be:

| Location | Status |
|----------|--------|
| `spec/01-data-model.md` | ❌ Not in example JSON, no sub-field table |
| `sdk/typescript/src/types/registry.ts` | ❌ Missing from `IssuerCapabilities` |
| `sdk/swift/.../Types.swift` | ❌ Missing from `IssuerCapabilities` struct |
| `registry/issuers/arcede.json` | ❌ Field absent in the only live issuer |
| `cli/src/commands/register.ts` | ❌ Scaffold template missing the field |
| SDK test fixtures | ❌ Constructions missing the field |

## Changes

- **`spec/01-data-model.md`**: Added `capabilities_verified: false` to example JSON + added a new "Capabilities Sub-fields" table (§2.1) documenting all six capability fields and their semantics
- **TypeScript SDK** (`types/registry.ts`): Added `capabilities_verified: boolean` with JSDoc linking to GOVERNANCE.md
- **Swift SDK** (`Types.swift`): Added `capabilitiesVerified: Bool` + CodingKeys mapping + updated test fixture
- **`registry/issuers/arcede.json`**: Added `"capabilities_verified": false` (Tier 1 status — not yet community-audited)
- **CLI `register.ts`**: Scaffold template now includes the field so new registrants start with the correct state
- **TypeScript `verify.test.ts`**: Both test issuer capability objects updated

## Notes

- No breaking changes; all existing tests continue to pass
- New registrants using the CLI `register` command will now correctly get `"capabilities_verified": false` in their scaffolded JSON — matching what the docs already promised them
- Services can now reliably read this field from SDK types to apply differentiated trust policies (as shown in `spec/09-service-integration.md`)