### PR TITLE
Spec 10: Encrypted Transport

### DIFF
--- a/spec/10-encrypted-transport.md
+++ b/spec/10-encrypted-transport.md
@@ -349,7 +349,8 @@ Relay implementations:
 - MUST enforce envelope TTL (`expiry_ts`). Expired envelopes MUST NOT be delivered.
 - MUST support HTTP polling for envelope retrieval.
 - SHOULD support WebSocket subscriptions for real-time delivery (critical for the revocation push model in §5.1).
-- MUST NOT require authentication for reading or writing envelopes. The cryptographic envelope is the access control.
+- SHOULD NOT require authentication beyond the cryptographic envelope for **writing** envelopes. The cryptographic envelope is the access control.
+- For **reading**, relay implementations MAY implement subscriber authentication (e.g., Ed25519 challenge-response) to limit metadata exposure to verified conversation participants. This does not weaken the cryptographic security model but improves delivery assurance — particularly valuable for the revocation push model in §5.1 where confirming that announcements reach intended recipients matters.
 - SHOULD implement rate limiting per IP address to mitigate abuse.
 
 ---


### PR DESCRIPTION
## Summary

Adds `spec/10-encrypted-transport.md` — defines how registry Ed25519 key material enables authenticated, E2E encrypted channels between verified agents and issuers.

- **Ed25519 → X25519 derivation** via RFC 7748 §4.1 birational mapping — no new key material
- **Registry-bound channel authentication** — encrypted channels are cryptographically tied to active registry entries
- **QSP-1-compatible envelope** — HKDF-SHA-256, XChaCha20-Poly1305, Ed25519 signatures inside encryption
- **Use cases** — real-time revocation push, inter-issuer coordination, confidential attestation delivery
- **Security analysis** — key reuse (signing + key agreement), channel-registry binding, metadata exposure, forward secrecy
- **WG-verified test vectors** — 5 Ed25519→X25519 vectors + HKDF key schedule vector, proven across 3 implementations

This is a protocol-level spec, not an implementation mandate. References qntm/QSP-1 as one compatible implementation without creating a hard dependency.

Refs #2

## Test plan

- [ ] Verify Ed25519→X25519 test vectors match WG-published vectors byte-for-byte
- [ ] Verify HKDF key derivation test vector produces correct output
- [ ] Confirm cross-references to specs 01, 03, 05, 07 resolve correctly
- [ ] Review security considerations section for completeness


🤖 Generated with [Claude Code](https://claude.com/claude-code)