### PR TITLE
Docs: complete registration flow in quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,7 @@ To read your private key later: `cat my-runtime.private.pem`
 
 > **macOS users:** Do not double-click `.private.pem` files. macOS will try to import them into Keychain Access, which is not what you want. Always use `cat` in the terminal.
 
-### 2. Register as a trusted runtime
-
-Create your registration file and submit a Pull Request:
+### 2. Create your registration file
 
 ```bash
 npx @open-agent-trust/cli register \
@@ -68,9 +66,38 @@ npx @open-agent-trust/cli register \
   --public-key <PUBLIC_KEY_FROM_STEP_1>
 ```
 
-This generates a `my-runtime.json` file. Submit a PR adding it to `registry/issuers/`.
+This generates a `my-runtime.json` file. Review the `capabilities` block to match your runtime's actual profile before submitting.
 
-### 3. Issue and verify attestations
+### 3. Host your domain verification file
+
+Host a `/.well-known/agent-trust.json` file at the website you declared in Step 2. This proves you control the domain — the same model used by Let's Encrypt and DNS-based domain verification.
+
+**At `https://my-runtime.com/.well-known/agent-trust.json`:**
+
+```json
+{
+  "issuer_id": "my-runtime",
+  "public_key_fingerprint": "my-runtime-2026-03"
+}
+```
+
+The `public_key_fingerprint` is the `kid` value printed during Step 1 (format: `{issuer-id}-{YYYY-MM}`). The CI pipeline will fetch this file and verify it matches your registration.
+
+### 4. Submit your Pull Request
+
+Open a PR against this repository adding your file to `registry/issuers/my-runtime.json`.
+
+Your PR **must** include a cryptographic **proof-of-key-ownership**: a file called `proof.txt` containing a signed statement. This proves you control the private key corresponding to the public key in your registration.
+
+```
+I control the Ed25519 key registered for issuer_id: my-runtime
+```
+
+Sign this statement with your private key. The CI pipeline verifies the signature against the public key in your registration file. See the [PR template](.github/PULL_REQUEST_TEMPLATE.md) for the full checklist.
+
+**Automated verification (Tier 1):** The CI pipeline checks three things — valid Ed25519 key, proof-of-key-ownership signature, and domain verification. If all three pass, the PR is auto-merged. No human approval required. See [GOVERNANCE.md](GOVERNANCE.md) for the full tiered model.
+
+### 5. Issue and verify attestations
 
 Once registered, your runtime can sign attestations (JWTs) to vouch for agents it runs:
 
@@ -86,7 +113,7 @@ npx @open-agent-trust/cli issue \
 npx @open-agent-trust/cli verify <JWT_STRING> --audience https://target-api.com
 ```
 
-### 4. Integrate into your application
+### 6. Integrate into your application
 
 ```bash
 npm install @open-agent-trust/registry


### PR DESCRIPTION
## Summary

The README quickstart was missing two required steps from `spec/02-registration.md`:

- **Domain verification** — hosting `/.well-known/agent-trust.json` at the declared website (Step 3 in spec 02)
- **Proof-of-key-ownership** — including a signed `proof.txt` in the PR (Step 4 in spec 02)

The quickstart previously jumped from "generate registration file" → "submit PR", skipping both. This meant anyone following the README alone would submit a PR that fails the CI verification checklist.

### Changes

- Added Step 3 (domain verification) with example JSON format for `agent-trust.json`
- Added Step 4 (proof-of-key-ownership) with the exact signed statement format from the PR template
- Renumbered existing steps 3-4 to 5-6
- Added note about reviewing the `capabilities` block before submitting

Refs #4

## Test plan

- [ ] Verify step numbering is sequential (1-6)
- [ ] Verify `agent-trust.json` example matches what spec 02 and GOVERNANCE.md describe
- [ ] Verify proof-of-key-ownership format matches `.github/PULL_REQUEST_TEMPLATE.md`
- [ ] Confirm cross-references to GOVERNANCE.md and PR template resolve


🤖 Generated with [Claude Code](https://claude.com/claude-code)