### PR TITLE
Register qntm as OATR issuer

### DIFF
--- a/registry/issuers/qntm.json
+++ b/registry/issuers/qntm.json
@@ -1,0 +1,29 @@
+{
+  "issuer_id": "qntm",
+  "display_name": "qntm",
+  "website": "https://inbox.qntm.corpo.llc",
+  "security_contact": "security@corpo.llc",
+  "status": "active",
+  "added_at": "2026-03-23T19:40:00.000Z",
+  "last_verified": "2026-03-23T19:40:00.000Z",
+  "public_keys": [
+    {
+      "kid": "qntm-relay-2026-03",
+      "algorithm": "Ed25519",
+      "public_key": "irD_bAvvt_KuQXaKAebRJBcp3SFFycDb2mEaxBCEC8k",
+      "status": "active",
+      "issued_at": "2026-03-23T19:40:00.000Z",
+      "expires_at": "2027-03-23T19:40:00.000Z",
+      "deprecated_at": null,
+      "revoked_at": null
+    }
+  ],
+  "capabilities": {
+    "supervision_model": "none",
+    "audit_logging": true,
+    "immutable_audit": false,
+    "attestation_format": "qsp1",
+    "max_attestation_ttl_seconds": 604800,
+    "capabilities_verified": false
+  }
+}

--- a/registry/proofs/qntm.proof
+++ b/registry/proofs/qntm.proof
@@ -1,0 +1,4 @@
+-----BEGIN OATR KEY OWNERSHIP PROOF-----
+Canonical-Message: oatr-proof-v1:qntm
+Signature: 4xSV7SqRvIYk6VE-2W0DNDEriusGOLd0MVjDub6ig-rgBo-EC5gWm3akw8TQfz2b4ST6zJtbbtkjnPoX8E5wBg
+-----END OATR KEY OWNERSHIP PROOF-----


### PR DESCRIPTION
## Registration: qntm

**Issuer ID:** `qntm`
**Display Name:** qntm
**Website:** https://inbox.qntm.corpo.llc
**Security Contact:** security@corpo.llc

### Identity

| Property | Value |
|----------|-------|
| Ed25519 Public Key | `irD_bAvvt_KuQXaKAebRJBcp3SFFycDb2mEaxBCEC8k` |
| Key ID (kid) | `qntm-relay-2026-03` |
| DID | `did:web:inbox.qntm.corpo.llc` |
| Sender ID | `f0a6e0c2a1cbbebc0306b5f744d2be70` |

### Verification

**Domain verification:** [`/.well-known/agent-trust.json`](https://inbox.qntm.corpo.llc/.well-known/agent-trust.json) — live, serving `issuer_id` + `public_key_fingerprint`.

**Proof of key ownership:** `registry/proofs/qntm.proof` — Ed25519 signature over `oatr-proof-v1:qntm`. Generated using the same private key that signs QSP-1 relay messages.

**DID Document:** [`/.well-known/did.json`](https://inbox.qntm.corpo.llc/.well-known/did.json) — same Ed25519 key in `Ed25519VerificationKey2020` format with multibase `z`-prefix.

### Unified Identity

The same Ed25519 keypair is used for:
1. **DID resolution** — `did:web:inbox.qntm.corpo.llc` verificationMethod
2. **QSP-1 relay transport** — envelope sender identity
3. **OATR registration** — this PR

One key, every layer of the trust stack.

### Context

qntm is a founding member of the [Agent Identity Working Group](https://github.com/corpollc/qntm/blob/main/specs/README.md). This registration anchors the encrypted transport layer in the trust registry, enabling end-to-end verification: DID resolution → registry verification → encrypted transport.

### Checklist

- [x] `registry/issuers/qntm.json` — valid issuer entry
- [x] `registry/proofs/qntm.proof` — proof-of-key-ownership (spec 11 format)
- [x] `/.well-known/agent-trust.json` — domain verification endpoint live
- [x] PR only touches `registry/issuers/` and `registry/proofs/` (CI file-scope safe)