### PR TITLE
feat(registry): register ArkForge as execution attestation issuer

### DIFF
--- a/registry/issuers/arkforge.json
+++ b/registry/issuers/arkforge.json
@@ -1,0 +1,29 @@
+{
+  "issuer_id": "arkforge",
+  "display_name": "ArkForge",
+  "website": "https://arkforge.tech",
+  "security_contact": "contact@arkforge.fr",
+  "status": "active",
+  "added_at": "2026-03-23T20:00:00.000Z",
+  "last_verified": "2026-03-23T20:00:00.000Z",
+  "public_keys": [
+    {
+      "kid": "arkforge-2026-03",
+      "algorithm": "Ed25519",
+      "public_key": "ZLlGE0eN0eTNUE9vaK1tStf6AuoFUWqJBvqx7QgxfEY",
+      "status": "active",
+      "issued_at": "2026-03-23T20:00:00.000Z",
+      "expires_at": "2027-03-23T20:00:00.000Z",
+      "deprecated_at": null,
+      "revoked_at": null
+    }
+  ],
+  "capabilities": {
+    "supervision_model": "tiered",
+    "audit_logging": true,
+    "immutable_audit": true,
+    "attestation_format": "json",
+    "max_attestation_ttl_seconds": 0,
+    "capabilities_verified": false
+  }
+}

--- a/registry/proofs/arkforge.proof
+++ b/registry/proofs/arkforge.proof
@@ -1,0 +1,4 @@
+-----BEGIN OATR KEY OWNERSHIP PROOF-----
+Canonical-Message: oatr-proof-v1:arkforge
+Signature: nBjp1MdQaqpB3fiurlscf0zgfUXHDItOnCdZN5eirq9Hu4Df7vn5HHkQi51xN67kQ3z7eyZNcayOIbHKmOgbAQ
+-----END OATR KEY OWNERSHIP PROOF-----


### PR DESCRIPTION
## Registration: ArkForge

ArkForge provides the **execution attestation layer** in the WG composability stack:
- Identity at rest: OATR attestations
- Identity in transit: qntm spec-10 encrypted transport
- Identity at execution: ArkForge proof receipts (this registration)

### Verification

**Domain:** https://arkforge.tech/.well-known/agent-trust.json ✓

**DID:** `did:web:trust.arkforge.tech` — bidirectional test confirmed with qntm in [OATR#2](https://github.com/FransDevelopment/open-agent-trust-registry/issues/2)

**Key alignment:** `Trunc16(SHA-256(pubkey))` = `174e20acd605f8ce6fca394246729bd7` matches qntm `sender_id` derivation — proven against live infrastructure.

**Proof-of-key-ownership:** `registry/proofs/arkforge.proof` — signed `oatr-proof-v1:arkforge` with the Ed25519 private key corresponding to `ZLlGE0eN0eTNUE9vaK1tStf6AuoFUWqJBvqx7QgxfEY`.

### Files

- `registry/issuers/arkforge.json`
- `registry/proofs/arkforge.proof`

🤖 Generated with [Claude Code](https://claude.com/claude-code)