### PR TITLE
Register Agent Passport System as OATR issuer

### DIFF
--- a/registry/issuers/agent-passport-system.json
+++ b/registry/issuers/agent-passport-system.json
@@ -1,0 +1,29 @@
+{
+  "issuer_id": "agent-passport-system",
+  "display_name": "Agent Passport System",
+  "website": "https://aeoess.com",
+  "security_contact": "signal@aeoess.com",
+  "status": "active",
+  "added_at": "2026-03-23T22:00:00.000Z",
+  "last_verified": "2026-03-23T22:00:00.000Z",
+  "public_keys": [
+    {
+      "kid": "aps-registry-2026-03",
+      "algorithm": "Ed25519",
+      "public_key": "Nf1alnpk2lPF5N_bmLS7heWTdLjSxr3ccIIJxt7VVsQ",
+      "status": "active",
+      "issued_at": "2026-03-23T22:00:00.000Z",
+      "expires_at": "2027-03-23T22:00:00.000Z",
+      "deprecated_at": null,
+      "revoked_at": null
+    }
+  ],
+  "capabilities": {
+    "supervision_model": "delegation_chain",
+    "audit_logging": true,
+    "immutable_audit": true,
+    "attestation_format": "aps-receipt-v1",
+    "max_attestation_ttl_seconds": 604800,
+    "capabilities_verified": false
+  }
+}

--- a/registry/proofs/agent-passport-system.proof
+++ b/registry/proofs/agent-passport-system.proof
@@ -1,0 +1,4 @@
+-----BEGIN OATR KEY OWNERSHIP PROOF-----
+Canonical-Message: oatr-proof-v1:agent-passport-system
+Signature: y4QPxRWqvTAeLRnLoC-XeDHh7oli4Uj1n33bo9bhl04PhoywmYB7TN5k7ICIyFzJSlgiJlIOKIgfgG1FEeorDQ
+-----END OATR KEY OWNERSHIP PROOF-----


### PR DESCRIPTION
Registering APS as a trusted issuer per Spec 02.

**Issuer:** agent-passport-system
**Website:** https://aeoess.com
**Domain verification:** https://aeoess.com/.well-known/agent-trust.json (live)
**Key:** Ed25519, kid: aps-registry-2026-03
**Proof:** Spec 11 format (detached Ed25519 signature over canonical message)
**Capabilities:** delegation_chain supervision, immutable audit logging, aps-receipt-v1 attestation

APS is a founding member of the Agent Identity Working Group (A2A #1672, qntm specs README).

cc @FransDevelopment @vessenes