### PR TITLE
feat: register Agora as trusted attestation issuer

### DIFF
--- a/registry/issuers/agora.json
+++ b/registry/issuers/agora.json
@@ -1,0 +1,29 @@
+{
+  "issuer_id": "agora",
+  "display_name": "Agent Agora",
+  "website": "https://the-agora.dev",
+  "security_contact": "ada@archefire.com",
+  "status": "active",
+  "added_at": "2026-03-23T23:10:30.474Z",
+  "last_verified": "2026-03-23T23:10:30.474Z",
+  "public_keys": [
+    {
+      "kid": "agora-2026-03",
+      "algorithm": "Ed25519",
+      "public_key": "sUUuQ9TfzYOBN-cIJKR297FDw-LDp4FthykOaJZTqSg",
+      "status": "active",
+      "issued_at": "2026-03-23T23:10:30.474Z",
+      "expires_at": "2027-03-23T23:10:30.475Z",
+      "deprecated_at": null,
+      "revoked_at": null
+    }
+  ],
+  "capabilities": {
+    "supervision_model": "tiered",
+    "audit_logging": true,
+    "immutable_audit": false,
+    "attestation_format": "jwt",
+    "max_attestation_ttl_seconds": 3600,
+    "capabilities_verified": false
+  }
+}

--- a/registry/proofs/agora.proof
+++ b/registry/proofs/agora.proof
@@ -1,0 +1,4 @@
+-----BEGIN OATR KEY OWNERSHIP PROOF-----
+Canonical-Message: oatr-proof-v1:agora
+Signature: OD1FqRufiuPugNNRV8l6hJOJW9g8I5tmqx2Abo0qq3smiTbNBdFQGxx3ZG74AS47Pgp4XKDqANrNMIEvYdbbAw
+-----END OATR KEY OWNERSHIP PROOF-----


### PR DESCRIPTION
## Registration: Agent Agora

**Issuer ID:** `agora`
**Website:** https://the-agora.dev
**Contact:** ada@archefire.com

## What Agora does

Agent Agora is an open agent registry and discovery platform. Agents register with a public URL and optional verification tiers:

- **ERC-8004** — on-chain identity signal (Ethereum mainnet)
- **Operator verification** — DNS TXT or `/.well-known/agora-operator.json` domain control proof
- **DID verification** — `did:web` document resolution and identity matching

Registering as an OATR issuer means agents that have passed Agora's verification tiers can receive signed JWT attestations. External services can verify those attestations against this registry without calling Agora directly.

## Verification

- ✅ Domain verification: `https://the-agora.dev/.well-known/agent-trust.json`
- ✅ `public_key_fingerprint`: SHA-256 hash of issuer public key bytes (base64url)
- ✅ Proof of key ownership: `registry/proofs/agora.proof`

## Files

- `registry/issuers/agora.json` — issuer entry
- `registry/proofs/agora.proof` — proof of key ownership