### PR TITLE
feat: register SINT Protocol as trusted issuer

### DIFF
--- a/registry/issuers/sint-protocol.json
+++ b/registry/issuers/sint-protocol.json
@@ -1,7 +1,7 @@
 {
   "issuer_id": "sint-protocol",
   "display_name": "SINT Protocol",
-  "website": "https://github.com/pshkv/sint-protocol",
+  "website": "https://sint.gg",
   "security_contact": "pshkv@users.noreply.github.com",
   "status": "active",
   "added_at": "2026-04-04T13:00:00.000Z",

--- a/registry/issuers/sint-protocol.json
+++ b/registry/issuers/sint-protocol.json
@@ -1,0 +1,29 @@
+{
+  "issuer_id": "sint-protocol",
+  "display_name": "SINT Protocol",
+  "website": "https://github.com/pshkv/sint-protocol",
+  "security_contact": "pshkv@users.noreply.github.com",
+  "status": "active",
+  "added_at": "2026-04-04T13:00:00.000Z",
+  "last_verified": "2026-04-04T13:00:00.000Z",
+  "public_keys": [
+    {
+      "kid": "sint-registry-2026-04",
+      "algorithm": "Ed25519",
+      "public_key": "Yq-yYyx7sLaMHE_jmTkgYPQoSJVJMDRfdAcInJxnV0E",
+      "status": "active",
+      "issued_at": "2026-04-04T13:00:00.000Z",
+      "expires_at": "2027-04-04T13:00:00.000Z",
+      "deprecated_at": null,
+      "revoked_at": null
+    }
+  ],
+  "capabilities": {
+    "supervision_model": "tiered",
+    "audit_logging": true,
+    "immutable_audit": true,
+    "attestation_format": "sint-token-v1",
+    "max_attestation_ttl_seconds": 604800,
+    "capabilities_verified": false
+  }
+}

--- a/registry/proofs/sint-protocol.proof
+++ b/registry/proofs/sint-protocol.proof
@@ -1,0 +1,4 @@
+-----BEGIN OATR KEY OWNERSHIP PROOF-----
+Canonical-Message: oatr-proof-v1:sint-protocol
+Signature: dh__7U68LI-2d8mfW4u8Zazw3P0i0OXCCbZFoLv4FpOawEpZpvLXSGo71GS4Ew72uji4eRoKeqdNLlMdUxZfBA
+-----END OATR KEY OWNERSHIP PROOF-----


### PR DESCRIPTION
## Summary

Registering **SINT Protocol** (`sint-protocol`) as an issuer in the Open Agent Trust Registry.

### What is SINT Protocol?

SINT is a runtime authorization framework for physical AI agents. It sits between AI agents and the physical world (robots, industrial systems, drones), ensuring every action is authorized, capability-constrained, and audited.

**Key properties:**
- **Identity**: Ed25519 keypairs + `did:key:z6Mk...` (W3C DID spec compliant)
- **Capability tokens**: Scoped, signed, delegatable — attenuation-only (permissions can only narrow)
- **Approval tiers**: T0 (observe) → T1 (prepare) → T2 (act, requires review) → T3 (commit, requires human sign-off)
- **Audit**: SHA-256 hash-chained `EvidenceLedger` — append-only, tamper-evident
- **Supervision model**: Tiered (T0–T3) with circuit breaker, goal hijack detection (ASI01), memory integrity (ASI06), supply chain verification (ASI04)

### APS↔SINT Interop

APS and SINT arrived at the same cryptographic primitives independently. Joint interop spec: https://github.com/aeoess/aps-sint-interop — 9/9 cross-verification tests pass with zero adapter code.

### Registration details

| Field | Value |
|---|---|
| `issuer_id` | `sint-protocol` |
| `kid` | `sint-registry-2026-04` |
| `algorithm` | Ed25519 |
| `supervision_model` | tiered |
| `immutable_audit` | true |
| `attestation_format` | sint-token-v1 |
| Source | https://github.com/pshkv/sint-protocol |

### Verification

- [x] Issuer JSON follows registry schema
- [x] Proof file: signature over `oatr-proof-v1:sint-protocol` with registered key
- [ ] Domain verification at `/.well-known/agent-trust.json` — endpoint exists in gateway-server discovery routes (deployed when gateway is hosted)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)