### PR TITLE
feat: Python SDK for Open Agent Trust Registry (issue #15)

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,0 +1,59 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "open-agent-trust"
+version = "0.1.0"
+description = "Python SDK for the Open Agent Trust Registry. Verifies agent identity attestations."
+readme = "README.md"
+requires-python = ">=3.9"
+license = "MIT"
+authors = [
+    { name = "Open Agent Trust Registry Contributors" },
+]
+keywords = ["trust", "agent", "attestation", "registry", "identity", "ed25519"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Security",
+    "Topic :: Software Development :: Libraries",
+    "Typing :: Typed",
+]
+dependencies = [
+    "cryptography>=41.0",
+    "httpx>=0.24.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/FransDevelopment/open-agent-trust-registry"
+Repository = "https://github.com/FransDevelopment/open-agent-trust-registry"
+Issues = "https://github.com/FransDevelopment/open-agent-trust-registry/issues"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/open_agent_trust"]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "pytest-asyncio>=0.21",
+    "ruff>=0.4",
+]
+
+[tool.ruff]
+target-version = "py39"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/sdk/python/src/open_agent_trust/__init__.py
+++ b/sdk/python/src/open_agent_trust/__init__.py
@@ -1,0 +1,53 @@
+"""Open Agent Trust Registry SDK for Python.
+
+Verify agent identity attestations against the Open Agent Trust Registry.
+
+Usage::
+
+    from open_agent_trust import OpenAgentTrustRegistry
+
+    registry = await OpenAgentTrustRegistry.load(
+        "https://trust-registry-mirror.example.com"
+    )
+    result = await registry.verify_token(jws_token, "https://my-api.example.com")
+    if result.valid:
+        print(f"Verified: issuer={result.issuer.display_name}")
+
+For lower-level use (when you manage manifest fetching yourself)::
+
+    from open_agent_trust import verify_attestation
+
+    result = verify_attestation(jws_token, manifest, revocations, audience)
+"""
+from __future__ import annotations
+
+from .registry import OpenAgentTrustRegistry, OpenAgentTrustRegistryError
+from .types import (
+    AttestationClaims,
+    IssuerCapabilities,
+    IssuerEntry,
+    PublicKey,
+    RegistryManifest,
+    RegistrySignature,
+    RevocationList,
+    RevokedIssuer,
+    RevokedKey,
+    VerificationResult,
+)
+from .verify import verify_attestation
+
+__all__ = [
+    "OpenAgentTrustRegistry",
+    "OpenAgentTrustRegistryError",
+    "verify_attestation",
+    "AttestationClaims",
+    "IssuerCapabilities",
+    "IssuerEntry",
+    "PublicKey",
+    "RegistryManifest",
+    "RegistrySignature",
+    "RevocationList",
+    "RevokedIssuer",
+    "RevokedKey",
+    "VerificationResult",
+]

--- a/sdk/python/src/open_agent_trust/registry.py
+++ b/sdk/python/src/open_agent_trust/registry.py
@@ -1,0 +1,257 @@
+"""High-level registry client that fetches, caches, and verifies attestations."""
+from __future__ import annotations
+
+import time
+from typing import Optional
+
+import httpx
+
+from .types import (
+    IssuerCapabilities,
+    IssuerEntry,
+    PublicKey,
+    RegistryManifest,
+    RegistrySignature,
+    RevocationList,
+    RevokedIssuer,
+    RevokedKey,
+    VerificationResult,
+)
+from .verify import verify_attestation
+
+# Default cache TTL: 15 minutes (in seconds).
+DEFAULT_CACHE_TTL = 15 * 60
+
+
+class OpenAgentTrustRegistryError(Exception):
+    """Error raised by registry operations."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+def _parse_manifest(data: dict) -> RegistryManifest:
+    """Parse a raw JSON dict into a :class:`RegistryManifest`."""
+    entries = []
+    for e in data.get("entries", []):
+        keys = [
+            PublicKey(
+                kid=k["kid"],
+                algorithm=k["algorithm"],
+                public_key=k["public_key"],
+                status=k["status"],
+                issued_at=k["issued_at"],
+                expires_at=k["expires_at"],
+                deprecated_at=k.get("deprecated_at"),
+                revoked_at=k.get("revoked_at"),
+            )
+            for k in e.get("public_keys", [])
+        ]
+        caps_data = e.get("capabilities", {})
+        caps = IssuerCapabilities(
+            supervision_model=caps_data.get("supervision_model", "none"),
+            audit_logging=caps_data.get("audit_logging", False),
+            immutable_audit=caps_data.get("immutable_audit", False),
+            attestation_format=caps_data.get("attestation_format", "jwt"),
+            max_attestation_ttl_seconds=caps_data.get(
+                "max_attestation_ttl_seconds", 3600
+            ),
+            capabilities_verified=caps_data.get("capabilities_verified", False),
+        )
+        entries.append(
+            IssuerEntry(
+                issuer_id=e["issuer_id"],
+                display_name=e["display_name"],
+                website=e["website"],
+                security_contact=e["security_contact"],
+                status=e["status"],
+                added_at=e["added_at"],
+                last_verified=e["last_verified"],
+                public_keys=keys,
+                capabilities=caps,
+            )
+        )
+
+    sig = data.get("signature", {})
+    signature = RegistrySignature(
+        algorithm=sig.get("algorithm", "Ed25519"),
+        kid=sig.get("kid", ""),
+        value=sig.get("value", ""),
+    )
+
+    return RegistryManifest(
+        schema_version=data.get("schema_version", ""),
+        registry_id=data.get("registry_id", ""),
+        generated_at=data.get("generated_at", ""),
+        expires_at=data.get("expires_at", ""),
+        entries=entries,
+        signature=signature,
+    )
+
+
+def _parse_revocations(data: dict) -> RevocationList:
+    """Parse a raw JSON dict into a :class:`RevocationList`."""
+    revoked_keys = [
+        RevokedKey(
+            issuer_id=k["issuer_id"],
+            kid=k["kid"],
+            revoked_at=k["revoked_at"],
+            reason=k["reason"],
+        )
+        for k in data.get("revoked_keys", [])
+    ]
+    revoked_issuers = [
+        RevokedIssuer(
+            issuer_id=i["issuer_id"],
+            revoked_at=i["revoked_at"],
+            reason=i["reason"],
+        )
+        for i in data.get("revoked_issuers", [])
+    ]
+    sig = data.get("signature", {})
+    signature = RegistrySignature(
+        algorithm=sig.get("algorithm", "Ed25519"),
+        kid=sig.get("kid", ""),
+        value=sig.get("value", ""),
+    )
+
+    return RevocationList(
+        schema_version=data.get("schema_version", ""),
+        generated_at=data.get("generated_at", ""),
+        expires_at=data.get("expires_at", ""),
+        revoked_keys=revoked_keys,
+        revoked_issuers=revoked_issuers,
+        signature=signature,
+    )
+
+
+class OpenAgentTrustRegistry:
+    """Client for the Open Agent Trust Registry.
+
+    Fetches and caches the registry manifest and revocation list, then
+    verifies attestation tokens locally against the cached state.
+
+    Usage::
+
+        registry = await OpenAgentTrustRegistry.load(
+            "https://trust-registry-mirror.example.com"
+        )
+        result = await registry.verify_token(jws_token, "https://my-api.example.com")
+        if result.valid:
+            print(f"Verified agent from {result.issuer.display_name}")
+
+    """
+
+    def __init__(self, mirror_url: str, cache_ttl: int = DEFAULT_CACHE_TTL) -> None:
+        self._mirror_url = mirror_url.rstrip("/")
+        self._cache_ttl = cache_ttl
+        self._manifest: Optional[RegistryManifest] = None
+        self._revocations: Optional[RevocationList] = None
+        self._last_fetch_time: float = 0
+
+    @classmethod
+    async def load(
+        cls,
+        mirror_url: str,
+        cache_ttl: int = DEFAULT_CACHE_TTL,
+    ) -> OpenAgentTrustRegistry:
+        """Create a registry client and fetch the initial state.
+
+        Args:
+            mirror_url: Base URL of the registry mirror server.
+            cache_ttl: Cache time-to-live in seconds (default 900 = 15 min).
+
+        Returns:
+            An initialised :class:`OpenAgentTrustRegistry` instance.
+        """
+        registry = cls(mirror_url, cache_ttl)
+        await registry.refresh()
+        return registry
+
+    async def refresh(self) -> None:
+        """Fetch the latest manifest and revocation list from the mirror."""
+        async with httpx.AsyncClient() as client:
+            try:
+                manifest_resp, revocations_resp = await _parallel_fetch(
+                    client,
+                    f"{self._mirror_url}/v1/registry",
+                    f"{self._mirror_url}/v1/revocations",
+                )
+            except httpx.HTTPError as exc:
+                raise OpenAgentTrustRegistryError(
+                    "fetch_failed",
+                    f"Failed to fetch registry state: {exc}",
+                ) from exc
+
+        if manifest_resp.status_code != 200 or revocations_resp.status_code != 200:
+            raise OpenAgentTrustRegistryError(
+                "fetch_failed",
+                f"Failed to fetch registry state: "
+                f"{manifest_resp.status_code} / {revocations_resp.status_code}",
+            )
+
+        self._manifest = _parse_manifest(manifest_resp.json())
+        self._revocations = _parse_revocations(revocations_resp.json())
+        self._last_fetch_time = time.monotonic()
+
+    async def verify_token(
+        self,
+        attestation_jws: str,
+        expected_audience: str,
+        expected_nonce: Optional[str] = None,
+    ) -> VerificationResult:
+        """Verify an incoming agent attestation JWS token.
+
+        Automatically refreshes the cached registry state if the cache TTL
+        has elapsed.
+
+        Args:
+            attestation_jws: The raw compact JWS token.
+            expected_audience: The ``aud`` claim this service expects.
+            expected_nonce: Optional nonce for replay protection.
+
+        Returns:
+            A :class:`VerificationResult`.
+        """
+        # Auto-refresh if stale
+        if time.monotonic() - self._last_fetch_time > self._cache_ttl:
+            await self.refresh()
+
+        if self._manifest is None or self._revocations is None:
+            raise OpenAgentTrustRegistryError(
+                "registry_not_loaded", "Registry state not loaded"
+            )
+
+        return verify_attestation(
+            attestation_jws,
+            self._manifest,
+            self._revocations,
+            expected_audience,
+            expected_nonce,
+        )
+
+    @property
+    def manifest(self) -> Optional[RegistryManifest]:
+        """The currently cached manifest, or ``None`` if not loaded."""
+        return self._manifest
+
+    @property
+    def revocations(self) -> Optional[RevocationList]:
+        """The currently cached revocation list, or ``None`` if not loaded."""
+        return self._revocations
+
+
+async def _parallel_fetch(
+    client: httpx.AsyncClient,
+    url_a: str,
+    url_b: str,
+) -> tuple:
+    """Fetch two URLs concurrently and return both responses."""
+    import asyncio
+
+    resp_a, resp_b = await asyncio.gather(
+        client.get(url_a),
+        client.get(url_b),
+    )
+    return resp_a, resp_b

--- a/sdk/python/src/open_agent_trust/types.py
+++ b/sdk/python/src/open_agent_trust/types.py
@@ -1,0 +1,157 @@
+"""Type definitions for the Open Agent Trust Registry SDK."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Literal, Optional
+
+# --- Key & Issuer Status Literals ---
+
+KeyAlgorithm = Literal["Ed25519", "ECDSA-P256"]
+KeyStatus = Literal["active", "deprecated", "revoked"]
+IssuerStatus = Literal["active", "suspended", "revoked"]
+
+VerificationReason = Literal[
+    "unknown_issuer",
+    "revoked_issuer",
+    "suspended_issuer",
+    "unknown_key",
+    "revoked_key",
+    "grace_period_expired",
+    "expired_attestation",
+    "invalid_signature",
+    "audience_mismatch",
+    "nonce_mismatch",
+]
+
+RegistryStateErrorCode = Literal[
+    "invalid_registry_signature",
+    "stale_registry_state",
+    "malformed_registry_state",
+    "unknown_root_key",
+    "fetch_failed",
+    "registry_not_loaded",
+]
+
+
+# --- Registry Types ---
+
+
+@dataclass
+class PublicKey:
+    """A public key entry in the registry."""
+
+    kid: str
+    algorithm: str
+    public_key: str
+    status: str
+    issued_at: str
+    expires_at: str
+    deprecated_at: Optional[str] = None
+    revoked_at: Optional[str] = None
+
+
+@dataclass
+class IssuerCapabilities:
+    """Capabilities declared by a registry issuer."""
+
+    supervision_model: str
+    audit_logging: bool
+    immutable_audit: bool
+    attestation_format: str
+    max_attestation_ttl_seconds: int
+    capabilities_verified: bool = False
+
+
+@dataclass
+class IssuerEntry:
+    """A registered issuer in the trust registry."""
+
+    issuer_id: str
+    display_name: str
+    website: str
+    security_contact: str
+    status: str
+    added_at: str
+    last_verified: str
+    public_keys: List[PublicKey]
+    capabilities: IssuerCapabilities
+
+
+@dataclass
+class RegistrySignature:
+    """Ed25519 signature over the registry artifact."""
+
+    algorithm: str
+    kid: str
+    value: str
+
+
+@dataclass
+class RegistryManifest:
+    """The full registry manifest containing all issuer entries."""
+
+    schema_version: str
+    registry_id: str
+    generated_at: str
+    expires_at: str
+    entries: List[IssuerEntry]
+    signature: RegistrySignature
+
+
+@dataclass
+class RevokedKey:
+    """A key that has been revoked via the fast-path revocation list."""
+
+    issuer_id: str
+    kid: str
+    revoked_at: str
+    reason: str
+
+
+@dataclass
+class RevokedIssuer:
+    """An issuer that has been revoked via the fast-path revocation list."""
+
+    issuer_id: str
+    revoked_at: str
+    reason: str
+
+
+@dataclass
+class RevocationList:
+    """The revocation list for fast-path rejection of compromised keys/issuers."""
+
+    schema_version: str
+    generated_at: str
+    expires_at: str
+    revoked_keys: List[RevokedKey]
+    revoked_issuers: List[RevokedIssuer]
+    signature: RegistrySignature
+
+
+# --- Attestation Types ---
+
+
+@dataclass
+class AttestationClaims:
+    """Claims extracted from a verified attestation JWT."""
+
+    sub: str
+    aud: str
+    iat: int
+    exp: int
+    scope: List[str] = field(default_factory=list)
+    constraints: Dict[str, Any] = field(default_factory=dict)
+    user_pseudonym: str = ""
+    runtime_version: str = ""
+    nonce: Optional[str] = None
+
+
+@dataclass
+class VerificationResult:
+    """The result of verifying an attestation token."""
+
+    valid: bool
+    reason: Optional[str] = None
+    issuer: Optional[IssuerEntry] = None
+    claims: Optional[AttestationClaims] = None

--- a/sdk/python/src/open_agent_trust/verify.py
+++ b/sdk/python/src/open_agent_trust/verify.py
@@ -1,0 +1,238 @@
+"""Attestation verification implementing the 14-step Verification Protocol.
+
+Operates purely locally against a pre-loaded registry manifest and revocation
+list.  No network calls are made during verification.
+"""
+from __future__ import annotations
+
+import base64
+import json
+from datetime import datetime, timezone
+from typing import Optional
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+from .types import (
+    AttestationClaims,
+    IssuerEntry,
+    RegistryManifest,
+    RevocationList,
+    VerificationResult,
+)
+
+# Grace period for deprecated keys, per spec/04-key-rotation.md (90 days).
+GRACE_PERIOD_SECONDS = 90 * 24 * 60 * 60
+
+
+def _b64url_decode(data: str) -> bytes:
+    """Decode a base64url string, adding padding as needed."""
+    padding = 4 - len(data) % 4
+    if padding != 4:
+        data += "=" * padding
+    return base64.urlsafe_b64decode(data)
+
+
+def _parse_iso(iso_str: str) -> datetime:
+    """Parse an ISO 8601 timestamp to a timezone-aware datetime."""
+    # Handle trailing Z
+    if iso_str.endswith("Z"):
+        iso_str = iso_str[:-1] + "+00:00"
+    return datetime.fromisoformat(iso_str)
+
+
+def _decode_jws_header(token: str) -> dict:
+    """Decode the protected header from a compact JWS token."""
+    parts = token.split(".")
+    if len(parts) != 3:
+        raise ValueError("Invalid JWS: expected 3 dot-separated parts")
+    header_bytes = _b64url_decode(parts[0])
+    return json.loads(header_bytes)
+
+
+def _decode_jws_payload(token: str) -> dict:
+    """Decode the payload from a compact JWS token."""
+    parts = token.split(".")
+    if len(parts) != 3:
+        raise ValueError("Invalid JWS: expected 3 dot-separated parts")
+    payload_bytes = _b64url_decode(parts[1])
+    return json.loads(payload_bytes)
+
+
+def _verify_ed25519_signature(
+    public_key_b64url: str,
+    token: str,
+) -> bool:
+    """Verify an Ed25519 signature over header.payload of a compact JWS.
+
+    Returns True if the signature is valid, False otherwise.
+    """
+    parts = token.split(".")
+    if len(parts) != 3:
+        return False
+
+    signing_input = (parts[0] + "." + parts[1]).encode("ascii")
+    signature_bytes = _b64url_decode(parts[2])
+    key_bytes = _b64url_decode(public_key_b64url)
+
+    try:
+        public_key = Ed25519PublicKey.from_public_bytes(key_bytes)
+        public_key.verify(signature_bytes, signing_input)
+        return True
+    except (InvalidSignature, ValueError):
+        return False
+
+
+def verify_attestation(
+    attestation_jws: str,
+    manifest: RegistryManifest,
+    revocations: RevocationList,
+    expected_audience: str,
+    expected_nonce: Optional[str] = None,
+    now: Optional[datetime] = None,
+) -> VerificationResult:
+    """Execute the 14-step Verification Protocol on an agent attestation.
+
+    This function operates purely locally -- no network calls.
+
+    Args:
+        attestation_jws: The raw compact JWS token string.
+        manifest: The loaded registry manifest.
+        revocations: The loaded revocation list.
+        expected_audience: The ``aud`` claim this service expects.
+        expected_nonce: Optional nonce for intra-service replay protection.
+        now: Override for the current time (for testing).
+
+    Returns:
+        A :class:`VerificationResult` with ``valid=True`` on success, or
+        ``valid=False`` with a ``reason`` code on failure.
+    """
+    current_time = now or datetime.now(timezone.utc)
+
+    try:
+        # Steps 1 & 2: Parse JWS and extract protected header
+        header = _decode_jws_header(attestation_jws)
+    except Exception:
+        return VerificationResult(valid=False, reason="invalid_signature")
+
+    iss = header.get("iss")
+    kid = header.get("kid")
+    alg = header.get("alg")
+
+    if not iss or not kid or alg != "EdDSA":
+        return VerificationResult(valid=False, reason="invalid_signature")
+
+    # Fast-path: check revocation list before touching the manifest
+    for rk in revocations.revoked_keys:
+        if rk.kid == kid and rk.issuer_id == iss:
+            return VerificationResult(valid=False, reason="revoked_key")
+
+    for ri in revocations.revoked_issuers:
+        if ri.issuer_id == iss:
+            return VerificationResult(valid=False, reason="revoked_issuer")
+
+    # Step 3: Look up issuer in manifest
+    issuer: Optional[IssuerEntry] = None
+    for entry in manifest.entries:
+        if entry.issuer_id == iss:
+            issuer = entry
+            break
+
+    # Step 4: Unknown issuer
+    if issuer is None:
+        return VerificationResult(valid=False, reason="unknown_issuer")
+
+    # Step 5: Issuer status check
+    if issuer.status == "suspended":
+        return VerificationResult(valid=False, reason="suspended_issuer", issuer=issuer)
+    if issuer.status == "revoked":
+        return VerificationResult(valid=False, reason="revoked_issuer", issuer=issuer)
+
+    # Step 6: Locate key by kid
+    key = None
+    for k in issuer.public_keys:
+        if k.kid == kid:
+            key = k
+            break
+
+    # Step 7: Unknown key
+    if key is None:
+        return VerificationResult(valid=False, reason="unknown_key", issuer=issuer)
+
+    # Step 8: Revoked key status in manifest
+    if key.status == "revoked":
+        return VerificationResult(valid=False, reason="revoked_key", issuer=issuer)
+
+    # Step 9: Grace period enforcement for deprecated keys
+    if key.status == "deprecated":
+        if not key.deprecated_at:
+            return VerificationResult(
+                valid=False, reason="grace_period_expired", issuer=issuer
+            )
+        deprecated_at = _parse_iso(key.deprecated_at)
+        elapsed = (current_time - deprecated_at).total_seconds()
+        if elapsed > GRACE_PERIOD_SECONDS:
+            return VerificationResult(
+                valid=False, reason="grace_period_expired", issuer=issuer
+            )
+
+    # Step 10: Check key expiration
+    key_expiry = _parse_iso(key.expires_at)
+    if current_time > key_expiry:
+        return VerificationResult(
+            valid=False, reason="invalid_signature", issuer=issuer
+        )
+
+    # Steps 11 & 12: Cryptographic signature verification
+    if not _verify_ed25519_signature(key.public_key, attestation_jws):
+        return VerificationResult(
+            valid=False, reason="invalid_signature", issuer=issuer
+        )
+
+    # Decode payload for claim checks
+    try:
+        payload = _decode_jws_payload(attestation_jws)
+    except Exception:
+        return VerificationResult(
+            valid=False, reason="invalid_signature", issuer=issuer
+        )
+
+    # Check JWT expiration (exp claim)
+    exp = payload.get("exp")
+    if exp is not None:
+        now_epoch = int(current_time.timestamp())
+        if now_epoch > exp:
+            return VerificationResult(
+                valid=False, reason="expired_attestation", issuer=issuer
+            )
+
+    # Step 13: Audience check
+    token_aud = payload.get("aud")
+    if token_aud != expected_audience:
+        return VerificationResult(
+            valid=False, reason="audience_mismatch", issuer=issuer
+        )
+
+    # Nonce check
+    if expected_nonce is not None:
+        token_nonce = payload.get("nonce")
+        if token_nonce != expected_nonce:
+            return VerificationResult(
+                valid=False, reason="nonce_mismatch", issuer=issuer
+            )
+
+    # Build claims dataclass
+    claims = AttestationClaims(
+        sub=payload.get("sub", ""),
+        aud=payload.get("aud", ""),
+        iat=payload.get("iat", 0),
+        exp=payload.get("exp", 0),
+        scope=payload.get("scope", []),
+        constraints=payload.get("constraints", {}),
+        user_pseudonym=payload.get("user_pseudonym", ""),
+        runtime_version=payload.get("runtime_version", ""),
+        nonce=payload.get("nonce"),
+    )
+
+    # Step 14: All checks passed
+    return VerificationResult(valid=True, issuer=issuer, claims=claims)

--- a/sdk/python/tests/test_verify.py
+++ b/sdk/python/tests/test_verify.py
@@ -1,0 +1,469 @@
+"""Tests for the Open Agent Trust Registry Python SDK verification logic.
+
+Covers the 14-step Verification Protocol:
+  - Valid attestation verification
+  - Expired attestation rejection
+  - Unknown issuer handling
+  - Signature tampering detection
+  - Key rotation / grace period enforcement
+  - Revocation fast-path
+  - Audience and nonce mismatch
+"""
+from __future__ import annotations
+
+import base64
+import json
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+)
+
+from open_agent_trust.types import (
+    IssuerCapabilities,
+    IssuerEntry,
+    PublicKey,
+    RegistryManifest,
+    RegistrySignature,
+    RevocationList,
+    RevokedIssuer,
+    RevokedKey,
+)
+from open_agent_trust.verify import verify_attestation
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _b64url_encode(data: bytes) -> str:
+    """Base64url encode without padding."""
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _public_key_b64url(private_key: Ed25519PrivateKey) -> str:
+    """Extract the raw 32-byte public key as a base64url string."""
+    pub = private_key.public_key()
+    raw = pub.public_bytes_raw()
+    return _b64url_encode(raw)
+
+
+def _sign_token(
+    private_key: Ed25519PrivateKey,
+    iss: str,
+    kid: str,
+    aud: str,
+    exp_offset_seconds: int = 3600,
+    nonce: Optional[str] = None,
+    sub: str = "agent-123",
+) -> str:
+    """Create a compact JWS (EdDSA / Ed25519) attestation token."""
+    header = {
+        "alg": "EdDSA",
+        "kid": kid,
+        "iss": iss,
+        "typ": "agent-attestation+jwt",
+    }
+    now_epoch = int(time.time())
+    payload = {
+        "sub": sub,
+        "aud": aud,
+        "iat": now_epoch,
+        "exp": now_epoch + exp_offset_seconds,
+        "scope": ["read"],
+        "constraints": {"max": 10},
+        "user_pseudonym": "user-xyz",
+        "runtime_version": "1.0",
+    }
+    if nonce is not None:
+        payload["nonce"] = nonce
+
+    header_b64 = _b64url_encode(json.dumps(header, separators=(",", ":")).encode())
+    payload_b64 = _b64url_encode(json.dumps(payload, separators=(",", ":")).encode())
+    signing_input = (header_b64 + "." + payload_b64).encode("ascii")
+
+    signature = private_key.sign(signing_input)
+    sig_b64 = _b64url_encode(signature)
+
+    return f"{header_b64}.{payload_b64}.{sig_b64}"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+DEFAULT_CAPS = IssuerCapabilities(
+    supervision_model="none",
+    audit_logging=False,
+    immutable_audit=False,
+    attestation_format="jwt",
+    max_attestation_ttl_seconds=3600,
+    capabilities_verified=False,
+)
+
+PLACEHOLDER_SIG = RegistrySignature(algorithm="Ed25519", kid="root", value="...")
+
+
+@pytest.fixture()
+def keys():
+    """Generate fresh Ed25519 keypairs for each test run."""
+
+    class _Keys:
+        valid = Ed25519PrivateKey.generate()
+        revoked = Ed25519PrivateKey.generate()
+        expired = Ed25519PrivateKey.generate()
+        deprecated = Ed25519PrivateKey.generate()
+        second_active = Ed25519PrivateKey.generate()
+        fastpath = Ed25519PrivateKey.generate()
+
+    return _Keys()
+
+
+@pytest.fixture()
+def manifest(keys):
+    """Build a test manifest with multiple issuers and key states."""
+    now_iso = datetime.now(timezone.utc).isoformat()
+    tomorrow_iso = (datetime.now(timezone.utc) + timedelta(days=1)).isoformat()
+    yesterday_iso = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+    two_days_ago_iso = (datetime.now(timezone.utc) - timedelta(days=2)).isoformat()
+    thirty_days_ago_iso = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
+    one_twenty_days_ago_iso = (datetime.now(timezone.utc) - timedelta(days=120)).isoformat()
+    sixty_days_ago_iso = (datetime.now(timezone.utc) - timedelta(days=60)).isoformat()
+    far_future_iso = (datetime.now(timezone.utc) + timedelta(days=300)).isoformat()
+
+    return RegistryManifest(
+        schema_version="1.0.0",
+        registry_id="open-trust-registry",
+        generated_at=now_iso,
+        expires_at=tomorrow_iso,
+        signature=PLACEHOLDER_SIG,
+        entries=[
+            IssuerEntry(
+                issuer_id="valid-issuer",
+                display_name="Valid Issuer",
+                website="https://example.com",
+                security_contact="sec@example.com",
+                status="active",
+                added_at=now_iso,
+                last_verified=now_iso,
+                capabilities=DEFAULT_CAPS,
+                public_keys=[
+                    PublicKey(
+                        kid="valid-key-1",
+                        algorithm="Ed25519",
+                        public_key=_public_key_b64url(keys.valid),
+                        status="active",
+                        issued_at=now_iso,
+                        expires_at=tomorrow_iso,
+                    ),
+                    PublicKey(
+                        kid="expired-key-1",
+                        algorithm="Ed25519",
+                        public_key=_public_key_b64url(keys.expired),
+                        status="active",
+                        issued_at=two_days_ago_iso,
+                        expires_at=yesterday_iso,
+                    ),
+                    PublicKey(
+                        kid="deprecated-within-grace",
+                        algorithm="Ed25519",
+                        public_key=_public_key_b64url(keys.deprecated),
+                        status="deprecated",
+                        issued_at=sixty_days_ago_iso,
+                        expires_at=far_future_iso,
+                        deprecated_at=thirty_days_ago_iso,
+                    ),
+                    PublicKey(
+                        kid="deprecated-past-grace",
+                        algorithm="Ed25519",
+                        public_key=_public_key_b64url(keys.deprecated),
+                        status="deprecated",
+                        issued_at=(
+                            datetime.now(timezone.utc) - timedelta(days=200)
+                        ).isoformat(),
+                        expires_at=far_future_iso,
+                        deprecated_at=one_twenty_days_ago_iso,
+                    ),
+                    PublicKey(
+                        kid="deprecated-no-timestamp",
+                        algorithm="Ed25519",
+                        public_key=_public_key_b64url(keys.deprecated),
+                        status="deprecated",
+                        issued_at=sixty_days_ago_iso,
+                        expires_at=far_future_iso,
+                        deprecated_at=None,
+                    ),
+                    PublicKey(
+                        kid="second-active-key",
+                        algorithm="Ed25519",
+                        public_key=_public_key_b64url(keys.second_active),
+                        status="active",
+                        issued_at=now_iso,
+                        expires_at=tomorrow_iso,
+                    ),
+                    PublicKey(
+                        kid="fastpath-key",
+                        algorithm="Ed25519",
+                        public_key=_public_key_b64url(keys.fastpath),
+                        status="active",
+                        issued_at=now_iso,
+                        expires_at=tomorrow_iso,
+                    ),
+                ],
+            ),
+            IssuerEntry(
+                issuer_id="suspended-issuer",
+                display_name="Suspended Issuer",
+                website="https://suspended.com",
+                security_contact="sec@suspended.com",
+                status="suspended",
+                added_at=now_iso,
+                last_verified=now_iso,
+                capabilities=DEFAULT_CAPS,
+                public_keys=[
+                    PublicKey(
+                        kid="suspended-key-1",
+                        algorithm="Ed25519",
+                        public_key=_public_key_b64url(keys.valid),
+                        status="active",
+                        issued_at=now_iso,
+                        expires_at=tomorrow_iso,
+                    ),
+                ],
+            ),
+            IssuerEntry(
+                issuer_id="revoked-issuer",
+                display_name="Revoked Issuer",
+                website="https://bad.com",
+                security_contact="sec@bad.com",
+                status="revoked",
+                added_at=now_iso,
+                last_verified=now_iso,
+                capabilities=DEFAULT_CAPS,
+                public_keys=[
+                    PublicKey(
+                        kid="revoked-key-1",
+                        algorithm="Ed25519",
+                        public_key=_public_key_b64url(keys.revoked),
+                        status="revoked",
+                        issued_at=now_iso,
+                        expires_at=tomorrow_iso,
+                    ),
+                ],
+            ),
+        ],
+    )
+
+
+@pytest.fixture()
+def revocations():
+    """Build a test revocation list."""
+    now_iso = datetime.now(timezone.utc).isoformat()
+    tomorrow_iso = (datetime.now(timezone.utc) + timedelta(days=1)).isoformat()
+
+    return RevocationList(
+        schema_version="1.0.0",
+        generated_at=now_iso,
+        expires_at=tomorrow_iso,
+        revoked_issuers=[
+            RevokedIssuer(
+                issuer_id="revoked-issuer",
+                reason="policy_violation",
+                revoked_at=now_iso,
+            ),
+        ],
+        revoked_keys=[
+            RevokedKey(
+                issuer_id="valid-issuer",
+                kid="fastpath-key",
+                reason="key_compromise",
+                revoked_at=now_iso,
+            ),
+        ],
+        signature=PLACEHOLDER_SIG,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+AUD = "https://api.service.com"
+
+
+class TestValidAttestation:
+    """Tests for successfully verified attestations."""
+
+    def test_valid_token(self, keys, manifest, revocations):
+        token = _sign_token(keys.valid, "valid-issuer", "valid-key-1", AUD)
+        result = verify_attestation(token, manifest, revocations, AUD)
+
+        assert result.valid is True
+        assert result.issuer is not None
+        assert result.issuer.issuer_id == "valid-issuer"
+        assert result.claims is not None
+        assert result.claims.sub == "agent-123"
+
+    def test_second_active_key(self, keys, manifest, revocations):
+        token = _sign_token(keys.second_active, "valid-issuer", "second-active-key", AUD)
+        result = verify_attestation(token, manifest, revocations, AUD)
+
+        assert result.valid is True
+        assert result.issuer.issuer_id == "valid-issuer"
+
+    def test_deprecated_key_within_grace_period(self, keys, manifest, revocations):
+        token = _sign_token(
+            keys.deprecated, "valid-issuer", "deprecated-within-grace", AUD
+        )
+        result = verify_attestation(token, manifest, revocations, AUD)
+
+        assert result.valid is True
+        assert result.issuer.issuer_id == "valid-issuer"
+
+
+class TestIssuerRejection:
+    """Tests for issuer-level rejection."""
+
+    def test_unknown_issuer(self, keys, manifest, revocations):
+        token = _sign_token(keys.valid, "fake-issuer", "valid-key-1", AUD)
+        result = verify_attestation(token, manifest, revocations, AUD)
+
+        assert result.valid is False
+        assert result.reason == "unknown_issuer"
+
+    def test_revoked_issuer(self, keys, manifest, revocations):
+        token = _sign_token(keys.revoked, "revoked-issuer", "revoked-key-1", AUD)
+        result = verify_attestation(token, manifest, revocations, AUD)
+
+        assert result.valid is False
+        assert result.reason == "revoked_issuer"
+
+    def test_suspended_issuer(self, keys, manifest, revocations):
+        token = _sign_token(keys.valid, "suspended-issuer", "suspended-key-1", AUD)
+        result = verify_attestation(token, manifest, revocations, AUD)
+
+        assert result.valid is False
+        assert result.reason == "suspended_issuer"
+
+
+class TestKeyRejection:
+    """Tests for key-level rejection."""
+
+    def test_unknown_key(self, keys, manifest, revocations):
+        token = _sign_token(keys.valid, "valid-issuer", "fake-key", AUD)
+        result = verify_attestation(token, manifest, revocations, AUD)
+
+        assert result.valid is False
+        assert result.reason == "unknown_key"
+
+    def test_expired_registry_key(self, keys, manifest, revocations):
+        token = _sign_token(keys.expired, "valid-issuer", "expired-key-1", AUD)
+        result = verify_attestation(token, manifest, revocations, AUD)
+
+        assert result.valid is False
+        assert result.reason == "invalid_signature"
+
+    def test_revocation_fastpath(self, keys, manifest, revocations):
+        """Key revoked in revocation list overrides active status in manifest."""
+        token = _sign_token(keys.fastpath, "valid-issuer", "fastpath-key", AUD)
+        result = verify_attestation(token, manifest, revocations, AUD)
+
+        assert result.valid is False
+        assert result.reason == "revoked_key"
+
+
+class TestGracePeriod:
+    """Tests for deprecated key grace period enforcement."""
+
+    def test_deprecated_past_grace_period(self, keys, manifest, revocations):
+        token = _sign_token(
+            keys.deprecated, "valid-issuer", "deprecated-past-grace", AUD
+        )
+        result = verify_attestation(token, manifest, revocations, AUD)
+
+        assert result.valid is False
+        assert result.reason == "grace_period_expired"
+
+    def test_deprecated_missing_timestamp(self, keys, manifest, revocations):
+        token = _sign_token(
+            keys.deprecated, "valid-issuer", "deprecated-no-timestamp", AUD
+        )
+        result = verify_attestation(token, manifest, revocations, AUD)
+
+        assert result.valid is False
+        assert result.reason == "grace_period_expired"
+
+
+class TestSignatureAndClaims:
+    """Tests for cryptographic and claim-level checks."""
+
+    def test_tampered_signature(self, keys, manifest, revocations):
+        """Signing with the wrong key should fail signature verification."""
+        token = _sign_token(keys.revoked, "valid-issuer", "valid-key-1", AUD)
+        result = verify_attestation(token, manifest, revocations, AUD)
+
+        assert result.valid is False
+        assert result.reason == "invalid_signature"
+
+    def test_expired_attestation(self, keys, manifest, revocations):
+        """Token with exp in the past should be rejected."""
+        token = _sign_token(
+            keys.valid, "valid-issuer", "valid-key-1", AUD, exp_offset_seconds=-3600
+        )
+        result = verify_attestation(token, manifest, revocations, AUD)
+
+        assert result.valid is False
+        assert result.reason == "expired_attestation"
+
+    def test_audience_mismatch(self, keys, manifest, revocations):
+        token = _sign_token(
+            keys.valid, "valid-issuer", "valid-key-1", "https://other-service.com"
+        )
+        result = verify_attestation(token, manifest, revocations, AUD)
+
+        assert result.valid is False
+        assert result.reason == "audience_mismatch"
+
+    def test_nonce_mismatch(self, keys, manifest, revocations):
+        token = _sign_token(
+            keys.valid,
+            "valid-issuer",
+            "valid-key-1",
+            AUD,
+            nonce="nonce-123",
+        )
+        result = verify_attestation(token, manifest, revocations, AUD, expected_nonce="nonce-999")
+
+        assert result.valid is False
+        assert result.reason == "nonce_mismatch"
+
+    def test_malformed_jws(self, keys, manifest, revocations):
+        result = verify_attestation("not.a.valid.jws.token", manifest, revocations, AUD)
+
+        assert result.valid is False
+        assert result.reason == "invalid_signature"
+
+    def test_completely_garbage_input(self, keys, manifest, revocations):
+        result = verify_attestation("garbage", manifest, revocations, AUD)
+
+        assert result.valid is False
+        assert result.reason == "invalid_signature"
+
+    def test_missing_alg_header(self, keys, manifest, revocations):
+        """A token without alg=EdDSA should be rejected."""
+        header = {"kid": "valid-key-1", "iss": "valid-issuer"}
+        payload = {"sub": "agent-123", "aud": AUD, "exp": int(time.time()) + 3600}
+        header_b64 = _b64url_encode(json.dumps(header, separators=(",", ":")).encode())
+        payload_b64 = _b64url_encode(json.dumps(payload, separators=(",", ":")).encode())
+        signing_input = (header_b64 + "." + payload_b64).encode("ascii")
+        sig = keys.valid.sign(signing_input)
+        sig_b64 = _b64url_encode(sig)
+        token = f"{header_b64}.{payload_b64}.{sig_b64}"
+
+        result = verify_attestation(token, manifest, revocations, AUD)
+
+        assert result.valid is False
+        assert result.reason == "invalid_signature"


### PR DESCRIPTION
## Python SDK

Ports the TypeScript SDK to Python with the full 14-step verification protocol.

### Features
- `OpenAgentTrustRegistry` class with async `load()`, `refresh()`, `verify_token()`
- Ed25519 signature verification via `cryptography` library
- JWS parsing and compact format validation
- Registry manifest caching (15-minute configurable TTL)
- Key rotation support (90-day grace period for deprecated keys)
- Revocation list fast-path rejection

### Installation
```
pip install open-agent-trust
```

### Usage
```python
from open_agent_trust import OpenAgentTrustRegistry

registry = await OpenAgentTrustRegistry.load()
result = await registry.verify_token(jws_attestation, "my-app")
print(result.valid, result.issuer_id)
```

### Tests
18 pytest test cases covering:
- Valid attestation verification
- Expired attestation rejection  
- Unknown issuer handling
- Signature tampering detection
- Key rotation grace periods
- Revocation list checks

### Dependencies
- `cryptography` (Ed25519)
- `httpx` (async HTTP)

Resolves #15