### PR TITLE
Register Nobulex as trusted issuer

### DIFF
--- a/registry/issuers/nobulex.json
+++ b/registry/issuers/nobulex.json
@@ -1,0 +1,29 @@
+{
+  "issuer_id": "nobulex",
+  "display_name": "Nobulex",
+  "website": "https://nobulex.com",
+  "security_contact": "security@nobulex.com",
+  "status": "active",
+  "added_at": "2026-04-16T22:49:05.364Z",
+  "last_verified": "2026-04-16T22:49:05.364Z",
+  "public_keys": [
+    {
+      "kid": "nobulex-2026-04",
+      "algorithm": "Ed25519",
+      "public_key": "tcduFPzTSehb-PPiL78GqS34nd6bzqrbxyZvQWZluB8",
+      "status": "active",
+      "issued_at": "2026-04-16T22:49:05.364Z",
+      "expires_at": "2027-04-16T22:49:05.365Z",
+      "deprecated_at": null,
+      "revoked_at": null
+    }
+  ],
+  "capabilities": {
+    "supervision_model": "tiered",
+    "audit_logging": true,
+    "immutable_audit": false,
+    "attestation_format": "jwt",
+    "max_attestation_ttl_seconds": 3600,
+    "capabilities_verified": false
+  }
+}

--- a/registry/proofs/nobulex.proof
+++ b/registry/proofs/nobulex.proof
@@ -1,0 +1,4 @@
+-----BEGIN OATR KEY OWNERSHIP PROOF-----
+Canonical-Message: oatr-proof-v1:nobulex
+Signature: KMMbNIXQ_va3szaiXz7LkdGmBoeH5ixJp3z9U_S0W0jQTcHu5blGv26edMJTkGZUW59apDwIuGRG_h6HQCSoAg
+-----END OATR KEY OWNERSHIP PROOF-----


### PR DESCRIPTION
Registering Nobulex (https://nobulex.com) as a trusted issuer.

Nobulex is an open-source cryptographic proof-of-behavior protocol for AI agents — hash-chained action logs, covenant enforcement, deterministic verification.

- `registry/issuers/nobulex.json` — issuer entry
- `registry/proofs/nobulex.proof` — proof-of-key-ownership
- Domain verification live at https://nobulex.com/.well-known/agent-trust.json

Generated via `@open-agent-trust/cli@1.1.0`. CI should auto-verify.