### PR TITLE
fix(ci): serialize manifest compiler to prevent push races

### DIFF
--- a/.github/workflows/manifest-compiler.yml
+++ b/.github/workflows/manifest-compiler.yml
@@ -17,6 +17,16 @@ on:
 permissions:
   contents: write
 
+# Serialize compiler runs so two invocations can't race each other when
+# the scheduled trigger and a push trigger (or two scheduled runs) overlap.
+# Without this, one run can check out commit X, start compiling, and a
+# second run can push X+1 before the first pushes, causing a non-fast-forward
+# rejection. `cancel-in-progress: false` queues rather than cancels so every
+# triggering event still produces a compile.
+concurrency:
+  group: registry-compiler
+  cancel-in-progress: false
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 


### PR DESCRIPTION
## Summary
- Adds a `concurrency` group to `.github/workflows/manifest-compiler.yml` so overlapping scheduled/push-triggered runs queue instead of racing.
- Fixes the intermittent non-fast-forward push rejections from \`stefanzweifel/git-auto-commit-action@v5\` (e.g. the failure at 07:30 UTC on 2026-04-24).

## Why this, not the other options
The misleading "forced update" line in the failing logs is a cosmetic artifact of \`actions/checkout@v4\`'s shallow fetch, not an actual history rewrite — the commit chain on \`main\` is linear and all pushes are from \`github-actions[bot]\`. Real cause: two scheduled runs overlapped, one pushed first, the second tried to push a commit built on the old tip.

Considered a \`git pull --rebase\` belt-and-suspenders before the auto-commit step, but rejected it: both sides modify \`registry/manifest.json\`, so rebase would either conflict or require a stash/reset dance that adds risk. The concurrency gate alone eliminates the race cleanly.

The Node 20 deprecation warning in those logs is unrelated — GitHub transparently forces those actions to Node 24 and they work.

## Test plan
- [x] YAML validated locally (\`yaml.safe_load\`)
- [x] Diff is additive only — no behavior changes to existing steps
- [ ] After merge, observe next few scheduled runs complete without non-fast-forward errors
- [ ] Confirm manual \`workflow_dispatch\` still triggers a run